### PR TITLE
Make imgsmlr compatible with PostgreSQL 16

### DIFF
--- a/imgsmlr.c
+++ b/imgsmlr.c
@@ -13,6 +13,9 @@
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
+#ifndef VARDATA_ANY
+#include "varatt.h"
+#endif
 
 #include "c.h"
 #include "fmgr.h"

--- a/imgsmlr.c
+++ b/imgsmlr.c
@@ -13,8 +13,10 @@
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
-#ifndef VARDATA_ANY
+#ifdef PG_VERSION_NUM
+#if PG_VERSION_NUM >= 160000
 #include "varatt.h"
+#endif
 #endif
 
 #include "c.h"

--- a/imgsmlr.h
+++ b/imgsmlr.h
@@ -37,3 +37,13 @@ typedef struct
 #define CHECK_SIGNATURE_KEY(key) Assert(VARSIZE_ANY_EXHDR(key) == sizeof(Signature) || VARSIZE_ANY_EXHDR(key) == 2 * sizeof(Signature));
 
 #endif   /* IMGSMLR_H */
+
+
+#ifndef FALSE
+#define FALSE   (0)
+#endif
+
+
+#ifndef TRUE
+#define TRUE    (!FALSE)
+#endif

--- a/imgsmlr_idx.c
+++ b/imgsmlr_idx.c
@@ -13,8 +13,11 @@
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
-#ifndef VARDATA_ANY
+
+#ifdef PG_VERSION_NUM
+#if PG_VERSION_NUM >= 160000
 #include "varatt.h"
+#endif
 #endif
 
 #include "fmgr.h"


### PR DESCRIPTION
First issue due to moving of several functions to varatt.h:

```
imgsmlr.c:106:2: warning: call to undeclared function 'SET_VARSIZE'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        SET_VARSIZE(pattern, sizeof(Pattern));
        ^
imgsmlr.c:128:32: warning: call to undeclared function 'VARSIZE_ANY_EXHDR'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        im = gdImageCreateFromJpegPtr(VARSIZE_ANY_EXHDR(img), VARDATA_ANY(img));
                                      ^
imgsmlr.c:128:56: warning: call to undeclared function 'VARDATA_ANY'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        im = gdImageCreateFromJpegPtr(VARSIZE_ANY_EXHDR(img), VARDATA_ANY(img));
                                                              ^
imgsmlr.c:128:56: error: incompatible integer to pointer conversion passing 'int' to parameter of type 'void *' [-Wint-conversion]
        im = gdImageCreateFromJpegPtr(VARSIZE_ANY_EXHDR(img), VARDATA_ANY(img));
```

For the second issue:

```
imgsmlr_idx.c: In function ‘signature_decompress’:
/usr/include/postgresql/16/server/fmgr.h:241:9: warning: passing argument 1 of ‘DatumGetPointer’ makes integer from pointer without a cast [-Wint-conversion]
  241 |         pg_detoast_datum((struct varlena *) DatumGetPointer(datum))
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |         |
      |         struct varlena *
/usr/include/postgresql/16/server/fmgr.h:331:60: note: in expansion of macro ‘PG_DETOAST_DATUM’
  331 | #define DatumGetByteaP(X)                       ((bytea *) PG_DETOAST_DATUM(X))
      |                                                            ^~~~~~~~~~~~~~~~
imgsmlr_idx.c:83:27: note: in expansion of macro ‘DatumGetByteaP’
   83 |         bytea      *key = DatumGetByteaP(PG_DETOAST_DATUM(entry->key));
      |                           ^~~~~~~~~~~~~~
imgsmlr_idx.c:83:42: note: in expansion of macro ‘PG_DETOAST_DATUM’
   83 |         bytea      *key = DatumGetByteaP(PG_DETOAST_DATUM(entry->key));
      |                                          ^~~~~~~~~~~~~~~~
In file included from imgsmlr_idx.c:15:
/usr/include/postgresql/16/server/postgres.h:312:23: note: expected ‘Datum’ {aka ‘long unsigned int’} but argument is of type ‘struct varlena *’
  312 | DatumGetPointer(Datum X)
      |                 ~~~~~~^
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wshadow=compatible-local -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -g -g -O2 -flto=auto -ffat-lto-objects -flto=auto -ffat-lto-objects -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer -fPIC -fvisibility=hidden -shared -o imgsmlr.so imgsmlr.o imgsmlr_idx.o -L/usr/lib/x86_64-linux-gnu  -Wl,-Bsymbolic-functions -flto=auto -ffat-lto-objects -flto=auto -Wl,-z,relro -Wl,-z,now -L/usr/lib/llvm-15/lib  -Wl,--as-needed -fvisibility=hidden -lgd 
/usr/bin/clang-15 -Wno-ignored-attributes -fno-strict-aliasing -fwrapv -Xclang -no-opaque-pointers -Wno-unused-command-line-argument -Wno-compound-token-split-by-macro -O2  -I. -I./ -I/usr/include/postgresql/16/server -I/usr/include/postgresql/internal  -Wdate-time -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE -I/usr/include/libxml2  -flto=thin -emit-llvm -c -o imgsmlr.bc imgsmlr.c
/usr/bin/clang-15 -Wno-ignored-attributes -fno-strict-aliasing -fwrapv -Xclang -no-opaque-pointers -Wno-unused-command-line-argument -Wno-compound-token-split-by-macro -O2  -I. -I./ -I/usr/include/postgresql/16/server -I/usr/include/postgresql/internal  -Wdate-time -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE -I/usr/include/libxml2  -flto=thin -emit-llvm -c -o imgsmlr_idx.bc imgsmlr_idx.c
imgsmlr_idx.c:83:33: error: incompatible pointer to integer conversion passing 'struct varlena *' to parameter of type 'Datum' (aka 'unsigned long') [-Wint-conversion]
        bytea      *key = DatumGetByteaP(PG_DETOAST_DATUM(entry->key));
                          ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
a slight rewrite of signature_decompress function had to be made.